### PR TITLE
Zooming tweak and dc wait time

### DIFF
--- a/pokubot/src/main/java/aok/coc/controller/MainWindowController.java
+++ b/pokubot/src/main/java/aok/coc/controller/MainWindowController.java
@@ -81,6 +81,8 @@ public class MainWindowController {
 	private Label				donateLabel;
 	@FXML
 	private Label				updateLabel;
+	@FXML
+	private TextField			dcWaitTimeField;
 
 	private static final Logger	logger			= Logger.getLogger(MainWindowController.class.getName());
 
@@ -244,6 +246,7 @@ public class MainWindowController {
 		elixirField.textProperty().addListener(intFieldListener);
 		deField.textProperty().addListener(intFieldListener);
 		maxThField.textProperty().addListener(intFieldListener);
+		dcWaitTimeField.textProperty().addListener(intFieldListener);
 	}
 
 	private void initializeComboBox() {
@@ -289,6 +292,7 @@ public class MainWindowController {
 		elixirField.setText(ConfigUtils.instance().getElixirThreshold() + "");
 		deField.setText(ConfigUtils.instance().getDarkElixirThreshold() + "");
 		maxThField.setText(ConfigUtils.instance().getMaxThThreshold() + "");
+		dcWaitTimeField.setText(ConfigUtils.instance().getDcWaitTime() + "");
 
 		isMatchAllConditionsCheckBox.setSelected(ConfigUtils.instance().isMatchAllConditions());
 		detectEmptyCollectorsCheckBox.setSelected(ConfigUtils.instance().isDetectEmptyCollectors());
@@ -330,6 +334,10 @@ public class MainWindowController {
 
 		if (!maxThField.getText().isEmpty()) {
 			ConfigUtils.instance().setMaxThThreshold(Integer.parseInt(maxThField.getText()));
+		}
+
+		if (!dcWaitTimeField.getText().isEmpty()) {
+			ConfigUtils.instance().setDcWaitTime(Integer.parseInt(dcWaitTimeField.getText()));
 		}
 
 		ConfigUtils.instance().setMatchAllConditions(isMatchAllConditionsCheckBox.isSelected());

--- a/pokubot/src/main/java/aok/coc/launcher/DisconnectChecker.java
+++ b/pokubot/src/main/java/aok/coc/launcher/DisconnectChecker.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 
 import aok.coc.state.Context;
 import aok.coc.state.StateIdle;
+import aok.coc.util.ConfigUtils;
 import aok.coc.util.RobotUtils;
 import aok.coc.util.coords.Clickable;
 
@@ -61,6 +62,7 @@ public class DisconnectChecker implements Runnable {
 					// when you click reload, screen would look like it is loaded for a second, before
 					// loading actually starts and next state would be executed.
 					StateIdle.instance().setReloading(true);
+					Thread.sleep(ConfigUtils.instance().getDcWaitTime());
 					RobotUtils.leftClick(Clickable.UNIT_RECONNECT, 5000);
 					Thread.sleep(2000);
 					StateIdle.instance().setReloading(false);

--- a/pokubot/src/main/java/aok/coc/util/ConfigUtils.java
+++ b/pokubot/src/main/java/aok/coc/util/ConfigUtils.java
@@ -49,12 +49,14 @@ public class ConfigUtils {
 	private static final String		PROPERTY_PLAY_SOUND					= "play_sound";
 	private static final String		PROPERTY_ATTACK_STRAT				= "attack_strat";
 	private static final String		PROPERTY_RAX_INFO					= "rax_info";
+	private static final String		PROPERTY_DC_WAIT_TIME					= "dc_wait";
 
 	// default values
 	private int						goldThreshold						= 0;
 	private int						elixirThreshold						= 0;
 	private int						darkElixirThreshold					= 0;
 	private int						maxThThreshold						= 0;
+	private int						dcWaitTime							= 0;
 
 	private boolean					matchAllConditions					= false;
 	private boolean					barracksConfigDone					= false;
@@ -161,6 +163,11 @@ public class ConfigUtils {
 				if (raxInfoProperty != null) {
 					instance.setRaxInfo(raxInfoProperty);
 				}
+
+				String dcWaitTimeProperty = configProperties.getProperty(PROPERTY_DC_WAIT_TIME);
+				if (dcWaitTimeProperty != null) {
+					instance.setDcWaitTime(Integer.parseInt(dcWaitTimeProperty));
+				}
 			} catch (Exception e) {
 				logger.log(Level.SEVERE, "Unable to read configuration file.", e);
 			}
@@ -195,6 +202,7 @@ public class ConfigUtils {
 			configProperties.setProperty(PROPERTY_DETECT_EMPTY_COLLECTORS, String.valueOf(detectEmptyCollectors));
 			configProperties.setProperty(PROPERTY_PLAY_SOUND, String.valueOf(playSound));
 			configProperties.setProperty(PROPERTY_ATTACK_STRAT, String.valueOf(attackStrategy.getClass().getSimpleName()));
+			configProperties.setProperty(PROPERTY_DC_WAIT_TIME, String.valueOf(dcWaitTime));
 
 			StringBuilder raxProp = new StringBuilder();
 			for (int i = 0; i < raxInfo.length; i++) {
@@ -345,4 +353,8 @@ public class ConfigUtils {
 	public Clickable[] getRaxInfo() {
 		return raxInfo;
 	}
+
+	public void setDcWaitTime(int dcWaitTime) { this.dcWaitTime = dcWaitTime; }
+
+	public int getDcWaitTime() { return this.dcWaitTime; }
 }

--- a/pokubot/src/main/java/aok/coc/util/ImageParser.java
+++ b/pokubot/src/main/java/aok/coc/util/ImageParser.java
@@ -14,7 +14,6 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.Buffer;
 import java.nio.file.*;
 import java.util.*;
 import java.util.List;

--- a/pokubot/src/main/java/aok/coc/util/ImageParser.java
+++ b/pokubot/src/main/java/aok/coc/util/ImageParser.java
@@ -14,6 +14,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.Buffer;
 import java.nio.file.*;
 import java.util.*;
 import java.util.List;
@@ -194,9 +195,12 @@ public class ImageParser {
 
 	static Rectangle findArea(BufferedImage input, String resourcePath) {
 		BufferedImage tar = fromResource(resourcePath);
+		return findArea(input, tar);
+	}
 
+	static Rectangle findArea(BufferedImage input, BufferedImage target) {
 		List<RegionMatch> doFindAll = TemplateMatcher.findMatchesByGrayscaleAtOriginalResolution(
-			input, tar, 1, 0.9);
+				input, target, 1, 0.9);
 
 		if (doFindAll.isEmpty()) {
 			return null;

--- a/pokubot/src/main/java/aok/coc/util/RobotUtils.java
+++ b/pokubot/src/main/java/aok/coc/util/RobotUtils.java
@@ -70,6 +70,8 @@ public class RobotUtils {
 
 	public static void zoomUp(int notch) throws InterruptedException {
 		logger.info("Zooming out...");
+		BufferedImage beforeZoomSampleScreenShot = null;
+
 		int lParam = 0x00000001 | (0x50 /*scancode*/<< 16) | 0x01000000 /*extended*/;
 
 		WPARAM wparam = new WinDef.WPARAM(VK_DOWN);
@@ -79,6 +81,12 @@ public class RobotUtils {
 		for (int i = 0; i < notch; i++) {
 			while (isCtrlKeyDown()) {
 			}
+
+			BufferedImage currentSampleScreenShot = screenShot(Area.SAMPLE_SCREEN);
+			if (beforeZoomSampleScreenShot != null &&
+					ImageParser.findArea(currentSampleScreenShot, beforeZoomSampleScreenShot) != null) return;
+			beforeZoomSampleScreenShot = currentSampleScreenShot;
+
 			User32.INSTANCE.PostMessage(handler, WM_KEYDOWN, wparam, lparamDown);
 			User32.INSTANCE.PostMessage(handler, WM_KEYUP, wparam, lparamUp);
 			Thread.sleep(1000);

--- a/pokubot/src/main/java/aok/coc/util/coords/Area.java
+++ b/pokubot/src/main/java/aok/coc/util/coords/Area.java
@@ -5,6 +5,8 @@ public enum Area {
 	ENEMY_LOOT(17, 70, 138, 240),
 	ATTACK_GROUP(24, 574, 836, 673),
 	ENEMY_BASE(31, 0, 831, 510),
+	SAMPLE_SCREEN(17, 70, 138, 240),
+
 	@Deprecated
 	BARRACKS_BUTTONS(188, 581, 679, 679);
 	
@@ -13,7 +15,7 @@ public enum Area {
 	private int	x2;
 	private int	y2;
 
-	private Area(int x1, int y1, int x2, int y2) {
+	Area(int x1, int y1, int x2, int y2) {
 		this.x1 = x1;
 		this.y1 = y1;
 		this.x2 = x2;

--- a/pokubot/src/main/resources/fxml/MainWindow.fxml
+++ b/pokubot/src/main/resources/fxml/MainWindow.fxml
@@ -12,7 +12,7 @@
 
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="543.0" prefWidth="887.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="aok.coc.controller.MainWindowController">
    <children>
-      <GridPane fx:id="configGridPane" layoutX="12.0" layoutY="80.0" prefHeight="353.0" prefWidth="330.0" visible="false" AnchorPane.leftAnchor="20.0" AnchorPane.topAnchor="80.0">
+      <GridPane fx:id="configGridPane" layoutX="12.0" layoutY="80.0" prefHeight="370.0" prefWidth="330.0" visible="false" AnchorPane.leftAnchor="20.0" AnchorPane.topAnchor="80.0">
          <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="209.0" minWidth="10.0" prefWidth="159.0" />
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="274.0" minWidth="10.0" prefWidth="171.0" />
@@ -30,6 +30,7 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
          </rowConstraints>
          <children>
@@ -49,7 +50,7 @@
             <CheckBox fx:id="playSoundCheckBox" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="6" />
             <Label text="Detect empty collectors?" GridPane.rowIndex="7" />
             <CheckBox fx:id="detectEmptyCollectorsCheckBox" mnemonicParsing="false" GridPane.columnIndex="1" GridPane.rowIndex="7" />
-            <HBox prefHeight="100.0" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="12">
+            <HBox prefHeight="100.0" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="13">
                <children>
                   <Button alignment="CENTER" mnemonicParsing="false" onAction="#handleSaveButtonAction" prefHeight="29.0" prefWidth="58.0" text="Save" />
                </children>
@@ -62,6 +63,8 @@
             <ComboBox fx:id="rax2ComboBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="9" />
             <ComboBox fx:id="rax3ComboBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="10" />
             <ComboBox fx:id="rax4ComboBox" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="11" />
+            <Label text="Dc wait time (ms)" GridPane.rowIndex="12" />
+            <TextField fx:id="dcWaitTimeField" prefHeight="16.0" prefWidth="51.0" text="0" GridPane.columnIndex="1" GridPane.rowIndex="12" />
          </children>
       </GridPane>
       <TextArea fx:id="textArea" editable="false" layoutX="367.0" layoutY="14.0" prefHeight="483.0" prefWidth="500.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="367.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="40.0" />

--- a/pokubot/src/test/java/aok/coc/util/TestRobotUtils.java
+++ b/pokubot/src/test/java/aok/coc/util/TestRobotUtils.java
@@ -6,7 +6,6 @@ import com.sun.jna.platform.win32.WinDef;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.awt.*;
 import java.io.IOException;
 
 /**

--- a/pokubot/src/test/java/aok/coc/util/TestRobotUtils.java
+++ b/pokubot/src/test/java/aok/coc/util/TestRobotUtils.java
@@ -1,0 +1,39 @@
+package aok.coc.util;
+
+import aok.coc.util.coords.Area;
+import aok.coc.util.w32.User32;
+import com.sun.jna.platform.win32.WinDef;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.awt.*;
+import java.io.IOException;
+
+/**
+ * Created by Rifqi on 8/9/2015.
+ */
+public class TestRobotUtils {
+
+    private static WinDef.HWND bsHwnd;
+    private static final String	BS_WINDOW_NAME	= "BlueStacks App Player";
+
+    @Before
+    public void setupWin32() {
+        bsHwnd = User32.INSTANCE.FindWindow(null, BS_WINDOW_NAME);
+    }
+
+    @Before
+    public void setupRobotUtil() {
+        RobotUtils.setupWin32(bsHwnd);
+    }
+
+    @Test
+    public void testSaveScreenShot() throws IOException {
+        RobotUtils.saveScreenShot(Area.SAMPLE_SCREEN, "debug", "base_" + System.currentTimeMillis());
+    }
+
+    @Test
+    public void testZoomUp() throws InterruptedException {
+        RobotUtils.zoomUp();
+    }
+}


### PR DESCRIPTION
I tweak zooming process so it doesn't notch again when it is fully zoomed out. For me it speeds up the process when camp is full so bot immediately find match.
Consideration: i took the upper left corner as comparison image and use sikuli's finder, please let me know if you have suggestions, or if you think this will affect performane or maybe causing bug. (Well it works for me atm)

Added feature dc wait time before bot click reload button. I use this feature personally so when i login through my phone remotely for checking or upgrading, i didn't get kicked instantly by bot.
However, current dc checker use clickable point as marker which in very rare occasion, marked main menu state as dc (maybe because of wall color?). Other known issue might be bot still trying to tap reload button (i believe this tap was intended for training troop) so it took some reloads on my phone before the dc wait timer goes on.

P.S sorry for my bad english
