### PR TITLE
Updated Clickable coords

### DIFF
--- a/pokubot/src/main/java/aok/coc/util/coords/Clickable.java
+++ b/pokubot/src/main/java/aok/coc/util/coords/Clickable.java
@@ -8,13 +8,13 @@ import java.awt.Color;
  */
 public enum Clickable {
 
-	BUTTON_ATTACK(63, 599, new Color(0xF0E8D8)), // make sure to pick a solid spot, some parts are transparent
+	BUTTON_ATTACK(63, 599, new Color(0xF0E4CB)), // make sure to pick a solid spot, some parts are transparent
 	BUTTON_ARMY_OVERVIEW(27, 524, new Color(0xF2E9D1)), // button above attack button
 	BUTTON_ARMY_OVERVIEW_NEXT(760, 326, new Color(0xF1873A)),
 	BUTTON_ARMY_OVERVIEW_CLOSE(729, 114, new Color(0xF8FCFF)),
-	BUTTON_ARMY_OVERVIEW_READY(149, 147, new Color(0x9BC73B)),
-	BUTTON_FIND_A_MATCH(148, 529, new Color(0xD84B00)),
-	BUTTON_SHIELD_DISABLE(512, 397, null),
+	BUTTON_ARMY_OVERVIEW_READY(136, 150, new Color(0x7A9F56)),
+	BUTTON_FIND_A_MATCH(290, 470, new Color(0xF0B028)),
+	BUTTON_SHIELD_DISABLE(435, 435, null),
 
 	// finding opponent
 	BUTTON_NEXT(817, 505, new Color(0xF0AA28)),


### PR DESCRIPTION
This pull request fixes the coordinates and colors of a few enums in the Clickable class because the TH11 update changed a lot of the artwork in the game. This should fix the issue of the bot getting stuck in several states.
